### PR TITLE
feat: Implement SignInScreen with reusable components

### DIFF
--- a/app/src/main/java/vn/tutorial/cinemate/MainActivity.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/MainActivity.kt
@@ -5,12 +5,15 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import vn.tutorial.cinemate.core.locale.ProvideAppLocale
+import vn.tutorial.cinemate.presentation.authentication.screens.SignInScreen
 import vn.tutorial.cinemate.presentation.settings.viewModel.SettingsViewModel
 import vn.tutorial.cinemate.ui.theme.CinemateTheme
 
@@ -27,10 +30,15 @@ class MainActivity : ComponentActivity() {
                 CinemateTheme(
                 ) {
                     Surface(
-                        modifier = Modifier.fillMaxSize(),
+                        modifier = Modifier
+                            .fillMaxSize(),
                         color = MaterialTheme.colorScheme.background
                     ) {
-
+                        Scaffold {
+                            SignInScreen(
+                                modifier = Modifier.padding(it)
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/vn/tutorial/cinemate/common/components/CommonButton.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/common/components/CommonButton.kt
@@ -1,0 +1,25 @@
+package vn.tutorial.cinemate.common.components
+
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import vn.tutorial.cinemate.common.styles.Styles
+
+@Composable
+fun CommonButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = { },
+    title: String
+) {
+    Button(
+        modifier = modifier.height(50.dp),
+        shape = Styles.ShapeStyles.smallCorner,
+        onClick = onClick
+    ) {
+        Text(title, style = MaterialTheme.typography.headlineSmall)
+    }
+}

--- a/app/src/main/java/vn/tutorial/cinemate/common/components/CommonTextField.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/common/components/CommonTextField.kt
@@ -1,0 +1,61 @@
+package vn.tutorial.cinemate.common.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import vn.tutorial.cinemate.common.styles.Styles
+
+@Composable
+fun CommonTextField(
+    modifier: Modifier = Modifier,
+    value: String,
+    isError: Boolean = false,
+    errorMessage: String? = null,
+    onValueChange: (String) -> Unit = {},
+    placeholder: String
+) {
+    Column(modifier = modifier) {
+        OutlinedTextField(
+            modifier = modifier
+                .background(MaterialTheme.colorScheme.surface)
+                .fillMaxWidth()
+                .height(56.dp),
+            value = value,
+            onValueChange = onValueChange,
+            shape = Styles.ShapeStyles.smallCorner,
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor = MaterialTheme.colorScheme.onPrimary,
+                errorBorderColor = MaterialTheme.colorScheme.error
+            ),
+            isError = isError,
+            singleLine = true,
+            placeholder = {
+                Text(
+                    placeholder,
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center
+                )
+            },
+            textStyle = MaterialTheme.typography.bodyMedium
+
+        )
+        if (isError && !errorMessage.isNullOrEmpty()) {
+            Text(
+                text = errorMessage,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(start = 8.dp, top = 4.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/java/vn/tutorial/cinemate/common/styles/Styles.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/common/styles/Styles.kt
@@ -1,0 +1,20 @@
+package vn.tutorial.cinemate.common.styles
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+object Styles {
+    object ShapeStyles {
+        val smallCorner = RoundedCornerShape(4.dp)
+        val mediumCorner = RoundedCornerShape(8.dp)
+        val largeCorner = RoundedCornerShape(16.dp)
+    }
+
+    object BorderStyles {
+        val thin = BorderStroke(1.dp, Color.Gray)
+        val thick = BorderStroke(2.dp, Color.Black)
+    }
+
+}

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/SignInScreen.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/SignInScreen.kt
@@ -1,0 +1,105 @@
+package vn.tutorial.cinemate.presentation.authentication.screens
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import vn.tutorial.cinemate.R
+import vn.tutorial.cinemate.common.components.CommonButton
+import vn.tutorial.cinemate.common.components.CommonTextField
+
+@Composable
+fun SignInScreen(
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = stringResource(R.string.sign_in),
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onPrimary
+        )
+
+        var username by remember { mutableStateOf("") }
+        var password by remember { mutableStateOf("") }
+        var isErrorEmail by remember { mutableStateOf(false) }
+        var isErrorPassword by remember { mutableStateOf(false) }
+
+        CommonTextField(
+            modifier = Modifier
+                .padding(top = 8.dp),
+            value = username,
+            onValueChange = {
+                username = it
+                isErrorEmail = it.length < 3
+            },
+            placeholder = stringResource(R.string.email_placeholder),
+            isError = isErrorEmail,
+            errorMessage = if (isErrorEmail) "Username quá ngắn" else null
+        )
+
+        CommonTextField(
+            modifier = Modifier
+                .padding(top = 16.dp),
+            value = password,
+            onValueChange = {
+                password = it
+                isErrorPassword = it.length < 3
+            },
+            placeholder = stringResource(R.string.password_placeholder),
+            isError = isErrorPassword,
+            errorMessage = if (isErrorPassword) "Password quá ngắn" else null
+        )
+
+        CommonButton(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 32.dp),
+            title = stringResource(R.string.sign_in)
+        )
+
+        Text(
+            modifier = Modifier
+                .padding(top = 32.dp)
+                .clickable(
+                    onClick = {}
+                ),
+            text = stringResource(R.string.forgot_password),
+            style = MaterialTheme.typography.bodyMedium.copy(
+                textDecoration = TextDecoration.Underline
+            )
+        )
+
+        Text(
+            modifier = Modifier
+                .padding(top = 48.dp)
+                .clickable(
+                    onClick = {}
+                ),
+            text = stringResource(R.string.register_account),
+            style = MaterialTheme.typography.bodyMedium.copy(
+                textDecoration = TextDecoration.Underline
+            )
+        )
+
+    }
+}

--- a/app/src/main/java/vn/tutorial/cinemate/ui/theme/Theme.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/ui/theme/Theme.kt
@@ -66,8 +66,6 @@ data class ColorFamily(
 @Composable
 fun CinemateTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
-    // Dynamic color is available on Android 12+
-    dynamicColor: Boolean = true,
     content: @Composable() () -> Unit
 ) {
     val colorScheme = if (darkTheme) darkScheme else lightScheme

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1,5 +1,10 @@
 <resources>
     <string name="app_name">Cinemate</string>
     <string name="welcome_message">Chào mừng đến với Cinemate!</string>
-    <string name="login">Đăng nhập</string>
+    <string name="sign_in">Đăng nhập</string>
+    <string name="sign_up">Đăng ký</string>
+    <string name="email_placeholder">Địa chỉ email</string>
+    <string name="password_placeholder">Mật khẩu</string>
+    <string name="forgot_password">Quên mật khẩu?</string>
+    <string name="register_account">Chưa có tài khoản? Đăng ký ngay !!!</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,11 @@
 <resources>
     <string name="app_name">Cinemate</string>
     <string name="welcome_message">Welcome to Cinemate!</string>
-    <string name="login">Login</string>
+    <string name="sign_in">Sign In</string>
+    <string name="sign_up">Sign Up</string>
+    <string name="email_placeholder">Email Address</string>
+    <string name="password_placeholder">Password</string>
+    <string name="forgot_password">Forgot Password?</string>
+    <string name="register_account">Don\'t Have An Account? Register Now !!!</string>
+
 </resources>


### PR DESCRIPTION
This commit introduces the `SignInScreen` along with reusable `CommonButton` and `CommonTextField` composables. It also defines common styles for shapes and borders.

- Added `CommonButton`: A reusable button component with customizable text and onClick action.
- Added `CommonTextField`: A reusable text field component with placeholder, error handling, and value change callback.
- Added `SignInScreen`: Implements the sign-in UI using the common components, including fields for email and password, sign-in button, and links for forgot password and registration.
- Added `Styles.kt`: Defines common shape styles (small, medium, large corners) and border styles (thin, thick).
- Updated `MainActivity` to display the `SignInScreen`.
- Updated `strings.xml` with new string resources for sign-in, sign-up, email/password placeholders, forgot password, and register account in both English and Vietnamese.
- Removed dynamic color theming in `Theme.kt`.