### PR TITLE
feat: Implement navigation for authentication screens

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,4 +59,5 @@ dependencies {
 
 
     implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.navigation.compose)
 }

--- a/app/src/main/java/vn/tutorial/cinemate/MainActivity.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/MainActivity.kt
@@ -13,7 +13,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import vn.tutorial.cinemate.core.locale.ProvideAppLocale
-import vn.tutorial.cinemate.presentation.authentication.screens.SignInScreen
+import vn.tutorial.cinemate.presentation.authentication.screens.SignUpScreen
+import vn.tutorial.cinemate.presentation.navigation.App
 import vn.tutorial.cinemate.presentation.settings.viewModel.SettingsViewModel
 import vn.tutorial.cinemate.ui.theme.CinemateTheme
 
@@ -34,9 +35,7 @@ class MainActivity : ComponentActivity() {
                             .fillMaxSize(),
                         color = MaterialTheme.colorScheme.background
                     ) {
-                        SignInScreen(
-                            modifier = Modifier.padding(16.dp)
-                        )
+                        App()
                     }
                 }
             }

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/SignUpScreen.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/SignUpScreen.kt
@@ -3,10 +3,12 @@ package vn.tutorial.cinemate.presentation.authentication.screens
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -28,7 +30,7 @@ import vn.tutorial.cinemate.common.components.CommonTextField
 import vn.tutorial.cinemate.presentation.navigation.Route
 
 @Composable
-fun SignInScreen(
+fun SignUpScreen(
     modifier: Modifier = Modifier,
     navController: NavHostController
 ) {
@@ -45,68 +47,62 @@ fun SignInScreen(
             modifier = modifier
                 .fillMaxSize()
                 .padding(it)
-                .padding(16.dp)
+                .padding(horizontal = 16.dp)
                 .imePadding(),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+
+            var email by remember { mutableStateOf("") }
+            var isErrorEmail by remember { mutableStateOf(false) }
+            var isChecked by remember { mutableStateOf(false) }
+
+
             Text(
-                text = stringResource(R.string.sign_in),
+                text = stringResource(R.string.sign_up),
                 style = MaterialTheme.typography.titleLarge,
                 color = MaterialTheme.colorScheme.onPrimary
             )
 
-            var username by remember { mutableStateOf("") }
-            var password by remember { mutableStateOf("") }
-            var isErrorEmail by remember { mutableStateOf(false) }
-            var isErrorPassword by remember { mutableStateOf(false) }
-
             CommonTextField(
                 modifier = Modifier
                     .padding(top = 8.dp),
-                value = username,
+                value = email,
                 onValueChange = {
-                    username = it
+                    email = it
                     isErrorEmail = it.length < 3
                 },
                 placeholder = stringResource(R.string.email_placeholder),
                 isError = isErrorEmail,
-                errorMessage = if (isErrorEmail) "Username quá ngắn" else null
+                errorMessage = if (isErrorEmail) "Email không đúng" else null
             )
 
-            CommonTextField(
+            Row(
                 modifier = Modifier
-                    .padding(top = 16.dp),
-                value = password,
-                onValueChange = {
-                    password = it
-                    isErrorPassword = it.length < 3
-                },
-                placeholder = stringResource(R.string.password_placeholder),
-                isError = isErrorPassword,
-                errorMessage = if (isErrorPassword) "Password quá ngắn" else null
-            )
+                    .padding(top = 16.dp)
+                    .fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Start,
+            ) {
+                Checkbox(
+                    checked = isChecked,
+                    onCheckedChange = { isChecked = it },
+                )
+
+                Text(
+                    text = stringResource(R.string.term),
+                    style = MaterialTheme.typography.bodySmall.copy(
+                        textDecoration = TextDecoration.Underline
+                    )
+                )
+            }
 
             CommonButton(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(top = 32.dp),
-                title = stringResource(R.string.sign_in),
+                title = stringResource(R.string.get_started),
                 onClick = {}
-            )
-
-            Text(
-                modifier = Modifier
-                    .padding(top = 32.dp)
-                    .clickable(
-                        onClick = {
-
-                        }
-                    ),
-                text = stringResource(R.string.forgot_password),
-                style = MaterialTheme.typography.bodyMedium.copy(
-                    textDecoration = TextDecoration.Underline
-                )
             )
 
             Text(
@@ -114,19 +110,18 @@ fun SignInScreen(
                     .padding(top = 48.dp)
                     .clickable(
                         onClick = {
-                            navController.navigate(Route.SignUp.route) {
-                                popUpTo(Route.SignIn.route) {
+                            navController.navigate(Route.SignIn.route) {
+                                popUpTo(Route.SignUp.route) {
                                     inclusive = true
                                 }
                             }
                         }
                     ),
-                text = stringResource(R.string.register_account),
+                text = stringResource(R.string.have_account),
                 style = MaterialTheme.typography.bodyMedium.copy(
                     textDecoration = TextDecoration.Underline
                 )
             )
-
         }
     }
 }

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/navigation/App.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/navigation/App.kt
@@ -1,0 +1,13 @@
+package vn.tutorial.cinemate.presentation.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.rememberNavController
+
+@Composable
+fun App() {
+    val navController = rememberNavController()
+    NavHost(navController, startDestination = Route.SignIn.route) {
+        authenticationNavGraph(navController)
+    }
+}

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/navigation/AppNavGraph.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/navigation/AppNavGraph.kt
@@ -1,0 +1,21 @@
+package vn.tutorial.cinemate.presentation.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import vn.tutorial.cinemate.presentation.authentication.screens.SignInScreen
+import vn.tutorial.cinemate.presentation.authentication.screens.SignUpScreen
+
+fun NavGraphBuilder.authenticationNavGraph(navController: NavHostController) {
+    composable(route = Route.SignIn.route) {
+        SignInScreen(
+            navController = navController
+        )
+    }
+
+    composable(route = Route.SignUp.route) {
+        SignUpScreen(
+            navController = navController
+        )
+    }
+}

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/navigation/Route.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/navigation/Route.kt
@@ -1,0 +1,6 @@
+package vn.tutorial.cinemate.presentation.navigation
+
+sealed class Route(val route: String) {
+    object SignIn: Route("sign_in")
+    object SignUp: Route("sign_up")
+}

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -7,4 +7,7 @@
     <string name="password_placeholder">Mật khẩu</string>
     <string name="forgot_password">Quên mật khẩu?</string>
     <string name="register_account">Chưa có tài khoản? Đăng ký ngay !!!</string>
+    <string name="term">Đồng ý với các điều khoản sử dụng</string>
+    <string name="get_started">Bắt đầu</string>
+    <string name="have_account">Đã có tài khoản? Đăng nhập</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,5 +7,7 @@
     <string name="password_placeholder">Password</string>
     <string name="forgot_password">Forgot Password?</string>
     <string name="register_account">Don\'t Have An Account? Register Now !!!</string>
-
+    <string name="term">Agree to the terms of use</string>
+    <string name="get_started">Get Started</string>
+    <string name="have_account">Already Have Account? Sign In</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ lifecycleRuntimeKtx = "2.9.3"
 activityCompose = "1.11.0"
 composeBom = "2024.09.00"
 
+navigationCompose = "2.9.4"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -27,6 +28,8 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
+
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This commit introduces navigation between the SignIn and SignUp screens using Jetpack Compose Navigation.

- Added `App.kt` to define the main navigation host.
- Created `AppNavGraph.kt` to manage the authentication navigation graph.
- Defined `Route.kt` to hold navigation routes for SignIn and SignUp.
- Implemented `SignUpScreen.kt` with UI elements for registration, including email input, terms agreement checkbox, and navigation to SignIn.
- Updated `SignInScreen.kt` to include navigation to `SignUpScreen` and enable back navigation.
- Modified `MainActivity.kt` to use the new `App` composable as the main content.
- Added `androidx.navigation:navigation-compose` dependency.
- Added new string resources for SignUp screen elements in both English and Vietnamese.
- Applied `imePadding()` to SignIn and SignUp screens to adjust for the keyboard.