### PR TITLE
feat: Implement CheckMailScreen and SetupPasswordScreen

### DIFF
--- a/app/src/main/java/vn/tutorial/cinemate/common/components/AppBar.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/common/components/AppBar.kt
@@ -19,7 +19,8 @@ import vn.tutorial.cinemate.R
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AppBar(
-    onBack: () -> Unit = {}
+    onBack: () -> Unit = {},
+    actions: @Composable () -> Unit = {}
 ) {
     TopAppBar(
         title = {
@@ -38,6 +39,9 @@ fun AppBar(
                     tint = MaterialTheme.colorScheme.onBackground
                 )
             }
+        },
+        actions = {
+            actions()
         },
         colors = TopAppBarDefaults.topAppBarColors(
             containerColor = MaterialTheme.colorScheme.background,

--- a/app/src/main/java/vn/tutorial/cinemate/common/components/CommonButton.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/common/components/CommonButton.kt
@@ -1,6 +1,7 @@
 package vn.tutorial.cinemate.common.components
 
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/CheckMailScreen.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/CheckMailScreen.kt
@@ -1,0 +1,115 @@
+package vn.tutorial.cinemate.presentation.authentication.screens
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import vn.tutorial.cinemate.R
+import vn.tutorial.cinemate.common.components.AppBar
+import vn.tutorial.cinemate.common.components.CommonButton
+import vn.tutorial.cinemate.presentation.navigation.Route
+
+@Composable
+fun CheckMailScreen(
+    email: String,
+    navController: NavHostController
+) {
+    Scaffold(
+        topBar = {
+            AppBar(
+                actions = {
+                    Text(
+                        modifier = Modifier
+                            .padding(end = 16.dp)
+                            .clickable(
+                                onClick = {
+                                    navController.navigate(Route.SignIn.route) {
+                                        popUpTo(Route.SignIn.route) {
+                                            inclusive = true
+                                        }
+                                    }
+                                }
+                            ),
+                        text = stringResource(R.string.sign_in),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onBackground
+                    )
+                }
+            )
+        }
+    ) {
+        Column(
+            Modifier
+                .fillMaxSize()
+                .padding(it)
+                .padding(horizontal = 32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+
+        ) {
+
+            Text(
+                modifier = Modifier.padding(vertical = 32.dp),
+                text = stringResource(R.string.complete_register),
+                style = MaterialTheme.typography.titleMedium
+            )
+
+            Text(
+                modifier = Modifier.padding(bottom = 16.dp),
+                text = underLineText(
+                    stringResource(R.string.almost_done, "%s"),
+                    email,
+                    MaterialTheme.colorScheme.primary,
+                    MaterialTheme.typography.bodyMedium.fontWeight!!
+                ),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+
+            Text(
+                text = stringResource(R.string.few_steps),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            CommonButton(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 32.dp),
+                title = stringResource(R.string.forward_email),
+                onClick = {
+                    navController.navigate(Route.CreatePassword.route)
+                }
+            )
+        }
+    }
+}
+
+fun underLineText(message: String, email: String, color: Color, fontWeight: FontWeight) =
+    buildAnnotatedString {
+        val parts = message.split("%s")
+        append(parts[0])
+        withStyle(
+            style = SpanStyle(
+                textDecoration = TextDecoration.Underline,
+                color = color,
+                fontWeight = fontWeight
+            ),
+
+            ) {
+            append(email)
+        }
+        if (parts.size > 1) append(parts[1])
+    }

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/SetupPasswordScreen.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/SetupPasswordScreen.kt
@@ -1,0 +1,106 @@
+package vn.tutorial.cinemate.presentation.authentication.screens
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import vn.tutorial.cinemate.R
+import vn.tutorial.cinemate.common.components.AppBar
+import vn.tutorial.cinemate.common.components.CommonButton
+import vn.tutorial.cinemate.common.components.CommonTextField
+import vn.tutorial.cinemate.presentation.navigation.Route
+
+@Composable
+fun SetupPasswordScreen(
+    modifier: Modifier = Modifier,
+    navController: NavController
+) {
+
+    Scaffold(
+        topBar = {
+            AppBar(
+                onBack = {
+                    navController.popBackStack()
+                },
+                actions = {
+                    Text(
+                        modifier = Modifier.padding(end = 16.dp).clickable(
+                            onClick = {
+                                navController.navigate(Route.SignIn.route) {
+                                    popUpTo(Route.SignIn.route) {
+                                        inclusive = true
+                                    }
+                                }
+                            }
+                        ),
+                        text = stringResource(R.string.sign_in),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onBackground
+                    )
+                }
+            )
+        }
+    ) {
+        Column(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(it)
+                .padding(horizontal = 16.dp)
+                .imePadding(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            var password by remember { mutableStateOf("") }
+            var confirmPassword by remember { mutableStateOf("") }
+            var isError by remember { mutableStateOf(false) }
+
+            Text(
+                modifier = Modifier.padding(bottom = 32.dp),
+                text = stringResource(R.string.create_password),
+                style = MaterialTheme.typography.titleLarge,
+            )
+
+            CommonTextField(
+                modifier = Modifier.padding(bottom = 16.dp),
+                value = password,
+                onValueChange = { password = it },
+                placeholder = stringResource(R.string.password_placeholder),
+            )
+            CommonTextField(
+                modifier = Modifier.padding(bottom = 16.dp),
+                value = confirmPassword,
+                onValueChange = {
+                    confirmPassword = it
+                    isError = it != password
+                },
+                isError = isError,
+                placeholder = stringResource(R.string.password_placeholder),
+                errorMessage = "Password does not match",
+            )
+
+            CommonButton(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 32.dp, bottom = 120.dp),
+                title = stringResource(R.string.confirm),
+                onClick = {}
+            )
+        }
+    }
+}

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/SignInScreen.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/SignInScreen.kt
@@ -100,7 +100,7 @@ fun SignInScreen(
                     .padding(top = 32.dp)
                     .clickable(
                         onClick = {
-
+                            navController.navigate(Route.ForgetPassword.route)
                         }
                     ),
                 text = stringResource(R.string.forgot_password),

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/SignUpScreen.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/SignUpScreen.kt
@@ -99,10 +99,11 @@ fun SignUpScreen(
 
             CommonButton(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 32.dp),
+                    .fillMaxWidth().padding(top = 32.dp),
                 title = stringResource(R.string.get_started),
-                onClick = {}
+                onClick = {
+                    navController.navigate(Route.CheckMail.route)
+                }
             )
 
             Text(

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/navigation/App.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/navigation/App.kt
@@ -7,7 +7,7 @@ import androidx.navigation.compose.rememberNavController
 @Composable
 fun App() {
     val navController = rememberNavController()
-    NavHost(navController, startDestination = Route.SignIn.route) {
+    NavHost(navController, startDestination = Route.CheckMail.route) {
         authenticationNavGraph(navController)
     }
 }

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/navigation/AppNavGraph.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/navigation/AppNavGraph.kt
@@ -3,6 +3,8 @@ package vn.tutorial.cinemate.presentation.navigation
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
+import vn.tutorial.cinemate.presentation.authentication.screens.CheckMailScreen
+import vn.tutorial.cinemate.presentation.authentication.screens.SetupPasswordScreen
 import vn.tutorial.cinemate.presentation.authentication.screens.SignInScreen
 import vn.tutorial.cinemate.presentation.authentication.screens.SignUpScreen
 
@@ -17,5 +19,17 @@ fun NavGraphBuilder.authenticationNavGraph(navController: NavHostController) {
         SignUpScreen(
             navController = navController
         )
+    }
+
+    composable(route = Route.CheckMail.route) {
+        CheckMailScreen("NhatTuan@gmail.com", navController)
+    }
+
+    composable(route = Route.CreatePassword.route) {
+        SetupPasswordScreen(navController = navController)
+    }
+
+    composable(route = Route.ForgetPassword.route) {
+
     }
 }

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/navigation/Route.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/navigation/Route.kt
@@ -3,4 +3,7 @@ package vn.tutorial.cinemate.presentation.navigation
 sealed class Route(val route: String) {
     object SignIn: Route("sign_in")
     object SignUp: Route("sign_up")
+    object CheckMail: Route("check_mail")
+    object CreatePassword: Route("create_password")
+    object ForgetPassword: Route("forgot_password")
 }

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1,13 +1,26 @@
 <resources>
     <string name="app_name">Cinemate</string>
     <string name="welcome_message">Chào mừng đến với Cinemate!</string>
+
+
     <string name="sign_in">Đăng nhập</string>
     <string name="sign_up">Đăng ký</string>
     <string name="email_placeholder">Địa chỉ email</string>
     <string name="password_placeholder">Mật khẩu</string>
+    <string name="password_confirm_placeholder">Xác nhận mật khẩu</string>
     <string name="forgot_password">Quên mật khẩu?</string>
     <string name="register_account">Chưa có tài khoản? Đăng ký ngay !!!</string>
     <string name="term">Đồng ý với các điều khoản sử dụng</string>
     <string name="get_started">Bắt đầu</string>
     <string name="have_account">Đã có tài khoản? Đăng nhập</string>
+    <string name="complete_register">Hoàn tất đăng ký để bắt đầu xem</string>
+    <string name="almost_done">Sắp xong rồi, chúng tôi vừa gửi email tới %s</string>
+    <string name="few_steps">Chỉ còn vài bước nữa để xem những bộ phim yêu thích của bạn</string>
+    <string name="forward_email">Tiếp tục đến email</string>
+    <string name="create_password">Thiết lập mật khẩu</string>
+    <string name="confirm">Xác nhận</string>
+    <string name="verify_email">Xác minh email</string>
+    <string name="update_password">Cập nhật mật khẩu</string>
+    <string name="instruct_update_password">Chúng tôi sẽ gửi email với hướng dẫn để đặt lại mật khẩu của bạn.</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,13 +1,27 @@
 <resources>
     <string name="app_name">Cinemate</string>
     <string name="welcome_message">Welcome to Cinemate!</string>
+
+    
     <string name="sign_in">Sign In</string>
     <string name="sign_up">Sign Up</string>
     <string name="email_placeholder">Email Address</string>
     <string name="password_placeholder">Password</string>
+    <string name="password_confirm_placeholder">Confirm Password</string>
     <string name="forgot_password">Forgot Password?</string>
     <string name="register_account">Don\'t Have An Account? Register Now !!!</string>
     <string name="term">Agree to the terms of use</string>
     <string name="get_started">Get Started</string>
     <string name="have_account">Already Have Account? Sign In</string>
+    <string name="complete_register">Complete registration to start watching</string>
+    <string name="almost_done">Almost done, we just sent an email to %s</string>
+    <string name="few_steps">Just a few steps away from watching your favorite movies</string>
+    <string name="forward_email">Continue to email</string>
+    <string name="create_password">Create Password</string>
+    <string name="confirm">Confirm</string>
+    <string name="verify_email">Verify Email</string>
+    <string name="update_password">Update Password</string>
+    <string name="instruct_update_password">We will send an email with instructions to reset your password.</string>
+    
+    
 </resources>


### PR DESCRIPTION
This commit introduces the `CheckMailScreen` and `SetupPasswordScreen` as part of the authentication flow.

- Added `CheckMailScreen`: Displays a message to the user after registration, prompting them to check their email for verification. It includes an option to navigate to the sign-in screen or proceed to create a password.
- Added `SetupPasswordScreen`: Allows users to set up or reset their password. It includes fields for new password and confirm password, with error handling for mismatched passwords.
- Updated `Route.kt` to include routes for `CheckMail`, `CreatePassword`, and `ForgetPassword`.
- Integrated the new screens into `AppNavGraph.kt`.
- Modified `App.kt` to start with `CheckMailScreen` for testing purposes.
- Updated `SignUpScreen` to navigate to `CheckMailScreen` upon successful registration.
- Updated `SignInScreen` to navigate to `ForgetPassword` route when "Forgot Password?" is clicked.
- Enhanced `AppBar.kt` to accept an `actions` composable for adding custom actions like a "Sign In" button.
- Added new string resources for the new screens in both English and Vietnamese, including messages for email verification, password setup, and password recovery.
- Added an `underLineText` utility function in `CheckMailScreen.kt` to display email addresses with an underline style.