### PR TITLE
feat: Implement VerifyEmail and ChangePassword screens

### DIFF
--- a/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/ChangePasswordScreen.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/ChangePasswordScreen.kt
@@ -1,0 +1,94 @@
+package vn.tutorial.cinemate.presentation.authentication.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import vn.tutorial.cinemate.R
+import vn.tutorial.cinemate.common.components.AppBar
+import vn.tutorial.cinemate.common.components.CommonButton
+import vn.tutorial.cinemate.common.components.CommonTextField
+import vn.tutorial.cinemate.presentation.navigation.Route
+
+@Composable
+fun ChangePasswordScreen(
+    modifier: Modifier = Modifier,
+    navController: NavHostController
+) {
+    Scaffold(
+        topBar = {
+            AppBar(
+                onBack = {
+                    navController.popBackStack()
+                }
+            )
+        }
+    ) {
+        Column(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(it)
+                .padding(horizontal = 16.dp)
+                .imePadding(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            var password by remember { mutableStateOf("") }
+            var confirmPassword by remember { mutableStateOf("") }
+            var isError by remember { mutableStateOf(false) }
+
+            Text(
+                modifier = Modifier.padding(bottom = 32.dp),
+                text = stringResource(R.string.change_password),
+                style = MaterialTheme.typography.titleLarge,
+            )
+
+            CommonTextField(
+                modifier = Modifier.padding(bottom = 16.dp),
+                value = password,
+                onValueChange = { password = it },
+                placeholder = stringResource(R.string.password_placeholder),
+            )
+            CommonTextField(
+                modifier = Modifier.padding(bottom = 16.dp),
+                value = confirmPassword,
+                onValueChange = {
+                    confirmPassword = it
+                    isError = it != password
+                },
+                isError = isError,
+                placeholder = stringResource(R.string.password_confirm_placeholder),
+                errorMessage = "Password does not match",
+            )
+
+            CommonButton(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 32.dp, bottom = 120.dp),
+                title = stringResource(R.string.change_password),
+                onClick = {
+                    navController.navigate(Route.Home.route) {
+                        popUpTo(Route.ChangePassword.route) {
+                            inclusive = true
+                        }
+                    }
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/SignInScreen.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/SignInScreen.kt
@@ -92,7 +92,13 @@ fun SignInScreen(
                     .fillMaxWidth()
                     .padding(top = 32.dp),
                 title = stringResource(R.string.sign_in),
-                onClick = {}
+                onClick = {
+                    navController.navigate(Route.Home.route) {
+                        popUpTo(Route.SignIn.route) {
+                            inclusive = true
+                        }
+                    }
+                }
             )
 
             Text(
@@ -100,7 +106,7 @@ fun SignInScreen(
                     .padding(top = 32.dp)
                     .clickable(
                         onClick = {
-                            navController.navigate(Route.ForgetPassword.route)
+                            navController.navigate(Route.VerifyEmail.route)
                         }
                     ),
                 text = stringResource(R.string.forgot_password),

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/VerifyEmailScreen.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/VerifyEmailScreen.kt
@@ -1,0 +1,76 @@
+package vn.tutorial.cinemate.presentation.authentication.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import vn.tutorial.cinemate.R
+import vn.tutorial.cinemate.common.components.AppBar
+import vn.tutorial.cinemate.common.components.CommonButton
+import vn.tutorial.cinemate.common.components.CommonTextField
+import vn.tutorial.cinemate.presentation.navigation.Route
+
+@Composable
+fun VerifyEmailScreen(
+    modifier: Modifier = Modifier,
+    navController: NavController
+) {
+    Scaffold(
+        topBar = {
+            AppBar()
+        }
+    ) {
+        Column(
+            modifier = modifier
+                .padding(it)
+                .padding(horizontal = 16.dp)
+                .fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+
+            var email by remember { mutableStateOf("") }
+
+            Text(
+                modifier = Modifier.padding(bottom = 32.dp),
+                text = stringResource(R.string.verify_email),
+                style = MaterialTheme.typography.titleLarge,
+            )
+            Text(
+                modifier = Modifier.padding(bottom = 32.dp),
+                text = stringResource(R.string.instruct_update_password),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            CommonTextField(
+                modifier = Modifier.padding(bottom = 16.dp),
+                value = email,
+                onValueChange = { email = it },
+                placeholder = stringResource(R.string.email_placeholder),
+            )
+
+            CommonButton(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 32.dp, bottom = 120.dp),
+                title = stringResource(R.string.confirm),
+                onClick = {
+                    navController.navigate(Route.ChangePassword.route)
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/home/HomeScreen.kt
@@ -1,0 +1,26 @@
+package vn.tutorial.cinemate.presentation.home
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun HomeScreen() {
+    Scaffold {
+        Column(
+            Modifier
+                .padding(it)
+                .fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text("Home Screen")
+        }
+    }
+}

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/navigation/App.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/navigation/App.kt
@@ -3,11 +3,12 @@ package vn.tutorial.cinemate.presentation.navigation
 import androidx.compose.runtime.Composable
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
+import vn.tutorial.cinemate.presentation.authentication.screens.VerifyEmailScreen
 
 @Composable
 fun App() {
     val navController = rememberNavController()
-    NavHost(navController, startDestination = Route.CheckMail.route) {
+    NavHost(navController, startDestination = Route.VerifyEmail.route) {
         authenticationNavGraph(navController)
     }
 }

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/navigation/AppNavGraph.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/navigation/AppNavGraph.kt
@@ -3,10 +3,13 @@ package vn.tutorial.cinemate.presentation.navigation
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
+import vn.tutorial.cinemate.presentation.authentication.screens.ChangePasswordScreen
 import vn.tutorial.cinemate.presentation.authentication.screens.CheckMailScreen
 import vn.tutorial.cinemate.presentation.authentication.screens.SetupPasswordScreen
 import vn.tutorial.cinemate.presentation.authentication.screens.SignInScreen
 import vn.tutorial.cinemate.presentation.authentication.screens.SignUpScreen
+import vn.tutorial.cinemate.presentation.authentication.screens.VerifyEmailScreen
+import vn.tutorial.cinemate.presentation.home.HomeScreen
 
 fun NavGraphBuilder.authenticationNavGraph(navController: NavHostController) {
     composable(route = Route.SignIn.route) {
@@ -29,7 +32,17 @@ fun NavGraphBuilder.authenticationNavGraph(navController: NavHostController) {
         SetupPasswordScreen(navController = navController)
     }
 
-    composable(route = Route.ForgetPassword.route) {
+    composable(route = Route.VerifyEmail.route) {
+        VerifyEmailScreen(navController = navController)
+    }
 
+    composable(route = Route.ChangePassword.route) {
+        ChangePasswordScreen(navController = navController)
+    }
+
+
+
+    composable(route = Route.Home.route) {
+        HomeScreen()
     }
 }

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/navigation/Route.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/navigation/Route.kt
@@ -5,5 +5,9 @@ sealed class Route(val route: String) {
     object SignUp: Route("sign_up")
     object CheckMail: Route("check_mail")
     object CreatePassword: Route("create_password")
-    object ForgetPassword: Route("forgot_password")
+    object ChangePassword: Route("change_password")
+    object VerifyEmail: Route("verify_email")
+
+
+    object Home: Route("home")
 }

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -20,7 +20,7 @@
     <string name="create_password">Thiết lập mật khẩu</string>
     <string name="confirm">Xác nhận</string>
     <string name="verify_email">Xác minh email</string>
-    <string name="update_password">Cập nhật mật khẩu</string>
+    <string name="change_password">Cập nhật mật khẩu</string>
     <string name="instruct_update_password">Chúng tôi sẽ gửi email với hướng dẫn để đặt lại mật khẩu của bạn.</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,7 +20,7 @@
     <string name="create_password">Create Password</string>
     <string name="confirm">Confirm</string>
     <string name="verify_email">Verify Email</string>
-    <string name="update_password">Update Password</string>
+    <string name="change_password">Update Password</string>
     <string name="instruct_update_password">We will send an email with instructions to reset your password.</string>
     
     


### PR DESCRIPTION
This commit introduces the `VerifyEmailScreen` and `ChangePasswordScreen` along with their navigation and a placeholder `HomeScreen`.

- Added `VerifyEmailScreen`: Allows users to input their email for password reset instructions. Navigates to `ChangePasswordScreen` on confirmation.
- Added `ChangePasswordScreen`: Allows users to set a new password and confirm it. Navigates to `HomeScreen` after successful password change.
- Added `HomeScreen`: A placeholder screen for future home content.
- Updated `Route.kt`:
    - Added `ChangePassword`, `VerifyEmail`, and `Home` routes.
    - Removed `ForgetPassword` route (replaced by `VerifyEmail`).
- Updated `AppNavGraph.kt`:
    - Added composables for `VerifyEmailScreen`, `ChangePasswordScreen`, and `HomeScreen`.
- Updated `App.kt`: Set `VerifyEmailScreen` as the initial start destination.
- Updated `SignInScreen.kt`:
    - "Forgot password" link now navigates to `VerifyEmailScreen`.
    - Sign-in button navigates to `HomeScreen` and clears the back stack up to `SignInScreen`.
- Updated `strings.xml`:
    - Renamed "update_password" to "change_password" for consistency.