### PR TITLE
feat: Implement HomeScreen and Navigation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,4 +65,5 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.foudation)
+    implementation(libs.coil.compose)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/vn/tutorial/cinemate/common/components/AppBar.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/common/components/AppBar.kt
@@ -1,6 +1,9 @@
 package vn.tutorial.cinemate.common.components
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -8,6 +11,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MediumTopAppBar
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable

--- a/app/src/main/java/vn/tutorial/cinemate/common/components/BottomBar.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/common/components/BottomBar.kt
@@ -1,0 +1,89 @@
+package vn.tutorial.cinemate.common.components
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import vn.tutorial.cinemate.R
+
+data class BottomNavItem(
+    val label: String,
+    val icon: Int,
+    val route: String
+)
+
+@Composable
+fun BottomBar(navController: NavHostController) {
+    val items = listOf(
+        BottomNavItem("Home", R.drawable.ic_home, "home"),
+        BottomNavItem("Search", R.drawable.ic_search, "search"),
+        BottomNavItem("Coming Soon", R.drawable.ic_coming_soon, "coming_soon"),
+        BottomNavItem("Notification", R.drawable.ic_notification, "notification"),
+        BottomNavItem("More", R.drawable.ic_more, "more")
+    )
+
+    NavigationBar(
+        containerColor = MaterialTheme.colorScheme.surface,
+        modifier = Modifier.height(110.dp)
+    ) {
+        val currentRoute = navController.currentBackStackEntryAsState().value?.destination?.route
+
+        items.forEach { item ->
+            val selected = currentRoute == item.route
+
+            // Animation scale khi chọn icon
+            val scale by animateFloatAsState(
+                targetValue = if (selected) 1.3f else 1f,
+                label = "iconScale"
+            )
+
+            NavigationBarItem(
+                selected = currentRoute == item.route,
+                onClick = {
+                    if (currentRoute != item.route) {
+                        navController.navigate(item.route) {
+                            popUpTo(navController.graph.startDestinationId) { saveState = true }
+                            launchSingleTop = true
+                            restoreState = true
+                        }
+                    }
+                },
+                icon = {
+                    Icon(
+                        painter = painterResource(item.icon),
+                        contentDescription = item.label,
+                        modifier = Modifier.scale(scale)
+                    )
+                },
+                label = {
+                    Text(
+                        item.label, style = MaterialTheme.typography.labelSmall.copy(
+                            fontSize = 10.sp
+                        )
+                    )
+                },
+                colors = NavigationBarItemDefaults.colors(
+                    indicatorColor = Color.Transparent,
+                    selectedIconColor = MaterialTheme.colorScheme.primary,
+                    unselectedIconColor = MaterialTheme.colorScheme.onBackground,
+                    selectedTextColor = MaterialTheme.colorScheme.primary,
+                    unselectedTextColor = MaterialTheme.colorScheme.onBackground
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/vn/tutorial/cinemate/common/components/CommonButton.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/common/components/CommonButton.kt
@@ -1,7 +1,6 @@
 package vn.tutorial.cinemate.common.components
 
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text

--- a/app/src/main/java/vn/tutorial/cinemate/common/components/RatingBar.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/common/components/RatingBar.kt
@@ -1,0 +1,71 @@
+package vn.tutorial.cinemate.common.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlin.math.cos
+import kotlin.math.sin
+
+@Composable
+fun RatingBar(
+    rating: Double,
+    modifier: Modifier = Modifier,
+    maxRating: Int = 5,
+    starSize: Dp = 24.dp,
+    starColor: Color = Color.Yellow
+) {
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+
+        Text(
+            modifier = Modifier.padding(end = 16.dp),
+            text = rating.toString(),
+            style = MaterialTheme.typography.bodyMedium.copy(
+                fontSize = 20.sp
+            )
+        )
+
+        for (i in 1..maxRating) {
+            val fillFraction = when {
+                i <= rating -> 1f
+                i - rating in 0.0..1.0 -> (rating - (i - 1)).toFloat()
+                else -> 0f
+            }
+
+            Canvas(
+                modifier = Modifier.size(starSize)
+            ) {
+                val path = Path().apply {
+                    moveTo(size.width / 2, 0f)
+                    for (j in 1..5) {
+                        val angle = Math.toRadians((j * 144).toDouble() - 90)
+                        lineTo(
+                            (size.width / 2 + size.width / 2 * cos(angle)).toFloat(),
+                            (size.height / 2 + size.height / 2 * sin(angle)).toFloat()
+                        )
+                    }
+                    close()
+                }
+
+                // vẽ sao rỗng
+                drawPath(path, color = starColor.copy(alpha = 0.3f))
+
+                // vẽ sao đầy theo fillFraction
+                clipRect(right = size.width * fillFraction) {
+                    drawPath(path, color = starColor)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/vn/tutorial/cinemate/common/components/SignInText.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/common/components/SignInText.kt
@@ -20,7 +20,6 @@ fun SignInText(
     Text(
         text = stringResource(R.string.sign_in),
         style = MaterialTheme.typography.bodyLarge,
-        color = Color.White,
         modifier = Modifier
             .padding(end = 16.dp)
             .clickable {

--- a/app/src/main/java/vn/tutorial/cinemate/navigation/App.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/navigation/App.kt
@@ -1,15 +1,47 @@
 package vn.tutorial.cinemate.navigation
 
+import android.annotation.SuppressLint
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import vn.tutorial.cinemate.common.components.BottomBar
 
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun App() {
     val navController = rememberNavController()
-    NavHost(navController, startDestination = Route.Splash.route) {
-        authenticationNavGraph(navController)
-        mainNavGraph(navController)
-    }
+    val route = currentRoute(navController)
 
+    val routeHasBottomBar = listOf(
+        Route.Home.route,
+        Route.ComingSoon.route,
+        Route.Notification.route,
+        Route.More.route,
+    )
+
+    Scaffold(
+        bottomBar = {
+            if (route in routeHasBottomBar) {
+                BottomBar(navController = navController)
+            }
+        }
+    ) {
+        NavHost(
+            navController = navController,
+            startDestination = Route.Home.route,
+        ) {
+            authenticationNavGraph(navController)
+            mainNavGraph(navController)
+        }
+    }
+}
+
+@Composable
+private fun currentRoute(navController: NavHostController): String? {
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    return navBackStackEntry?.destination?.route
 }

--- a/app/src/main/java/vn/tutorial/cinemate/navigation/AppNavGraph.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/navigation/AppNavGraph.kt
@@ -1,6 +1,5 @@
 package vn.tutorial.cinemate.navigation
 
-import vn.tutorial.cinemate.presentation.splash.screens.SplashScreen
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
@@ -11,8 +10,12 @@ import vn.tutorial.cinemate.presentation.authentication.screens.SetupPasswordScr
 import vn.tutorial.cinemate.presentation.authentication.screens.SignInScreen
 import vn.tutorial.cinemate.presentation.authentication.screens.SignUpScreen
 import vn.tutorial.cinemate.presentation.authentication.screens.VerifyEmailScreen
-import vn.tutorial.cinemate.presentation.home.HomeScreen
-import vn.tutorial.cinemate.presentation.settings.screens.ProfileScreen
+import vn.tutorial.cinemate.presentation.comingSoon.ComingSoonScreen
+import vn.tutorial.cinemate.presentation.home.screens.HomeScreen
+import vn.tutorial.cinemate.presentation.more.MoreScreen
+import vn.tutorial.cinemate.presentation.notification.NotificationScreen
+import vn.tutorial.cinemate.presentation.search.SearchScreen
+import vn.tutorial.cinemate.presentation.splash.screens.SplashScreen
 
 fun NavGraphBuilder.authenticationNavGraph(navController: NavHostController) {
 
@@ -63,11 +66,10 @@ fun NavGraphBuilder.authenticationNavGraph(navController: NavHostController) {
 }
 
 fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
-    composable(route = Route.Profile.route) {
-        ProfileScreen()
-    }
-
-    composable(route = Route.Home.route) {
-        HomeScreen()
-    }
+    composable(Route.Home.route) { HomeScreen() }
+    composable(Route.Search.route) { SearchScreen() }
+    composable(Route.ComingSoon.route) { ComingSoonScreen() }
+    composable(Route.Notification.route) { NotificationScreen() }
+    composable(Route.More.route) { MoreScreen() }
 }
+

--- a/app/src/main/java/vn/tutorial/cinemate/navigation/Route.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/navigation/Route.kt
@@ -1,6 +1,10 @@
 package vn.tutorial.cinemate.navigation
 
 sealed class Route(val route: String) {
+    //todo route splash
+    object Splash: Route("splash")
+
+    // todo route auth
     object SignIn: Route("sign_in")
     object SignUp: Route("sign_up")
     object CheckMail: Route("check_mail")
@@ -8,9 +12,13 @@ sealed class Route(val route: String) {
     object ChangePassword: Route("change_password")
     object VerifyEmail: Route("verify_email")
 
-    object Profile: Route("profile")
 
+    // todo route main
+    object Main: Route("main")
     object Home: Route("home")
+    object More: Route("more")
+    object Notification: Route("notification")
+    object ComingSoon: Route("coming_soon")
+    object Search: Route("search")
 
-    object Splash: Route("splash")
 }

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/ChangePasswordScreen.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/ChangePasswordScreen.kt
@@ -1,5 +1,6 @@
 package vn.tutorial.cinemate.presentation.authentication.screens
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -26,6 +27,8 @@ import vn.tutorial.cinemate.core.util.Validator
 import vn.tutorial.cinemate.presentation.authentication.components.PasswordTextField
 import vn.tutorial.cinemate.navigation.Route
 
+
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun ChangePasswordScreen(
     modifier: Modifier = Modifier,
@@ -43,7 +46,6 @@ fun ChangePasswordScreen(
         Column(
             modifier = modifier
                 .fillMaxSize()
-                .padding(it)
                 .padding(horizontal = 16.dp)
                 .imePadding(),
             verticalArrangement = Arrangement.Center,

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/SetupPasswordScreen.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/SetupPasswordScreen.kt
@@ -1,5 +1,6 @@
 package vn.tutorial.cinemate.presentation.authentication.screens
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -27,6 +28,7 @@ import vn.tutorial.cinemate.core.util.Validator
 import vn.tutorial.cinemate.navigation.Route
 import vn.tutorial.cinemate.presentation.authentication.components.PasswordTextField
 
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun SetupPasswordScreen(
     modifier: Modifier = Modifier,
@@ -44,7 +46,6 @@ fun SetupPasswordScreen(
         Column(
             modifier = modifier
                 .fillMaxSize()
-                .padding(it)
                 .padding(horizontal = 16.dp)
                 .imePadding(),
             verticalArrangement = Arrangement.Center,

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/SignInScreen.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/SignInScreen.kt
@@ -1,5 +1,6 @@
 package vn.tutorial.cinemate.presentation.authentication.screens
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -29,6 +30,7 @@ import vn.tutorial.cinemate.presentation.authentication.components.EmailTextFiel
 import vn.tutorial.cinemate.presentation.authentication.components.PasswordTextField
 import vn.tutorial.cinemate.navigation.Route
 
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun SignInScreen(
     modifier: Modifier = Modifier,
@@ -46,7 +48,6 @@ fun SignInScreen(
         Column(
             modifier = modifier
                 .fillMaxSize()
-                .padding(it)
                 .padding(16.dp)
                 .imePadding(),
             verticalArrangement = Arrangement.Center,
@@ -61,7 +62,6 @@ fun SignInScreen(
             var email by remember { mutableStateOf("") }
             var password by remember { mutableStateOf("") }
             var isValidEmail: Boolean? by remember { mutableStateOf(null) }
-//            var isValidPassword: Boolean? by remember { mutableStateOf(null) }
 
             EmailTextField(
                 modifier = Modifier

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/SignUpScreen.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/SignUpScreen.kt
@@ -1,5 +1,6 @@
 package vn.tutorial.cinemate.presentation.authentication.screens
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -29,7 +30,7 @@ import vn.tutorial.cinemate.common.components.CommonButton
 import vn.tutorial.cinemate.core.util.Validator
 import vn.tutorial.cinemate.presentation.authentication.components.EmailTextField
 import vn.tutorial.cinemate.navigation.Route
-
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun SignUpScreen(
     modifier: Modifier = Modifier,
@@ -47,7 +48,6 @@ fun SignUpScreen(
         Column(
             modifier = modifier
                 .fillMaxSize()
-                .padding(it)
                 .padding(horizontal = 16.dp)
                 .imePadding(),
             verticalArrangement = Arrangement.Center,

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/VerifyEmailScreen.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/VerifyEmailScreen.kt
@@ -1,5 +1,6 @@
 package vn.tutorial.cinemate.presentation.authentication.screens
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -26,7 +27,7 @@ import vn.tutorial.cinemate.core.helper.openMail
 import vn.tutorial.cinemate.core.util.Validator
 import vn.tutorial.cinemate.presentation.authentication.components.EmailTextField
 import vn.tutorial.cinemate.navigation.Route
-
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun VerifyEmailScreen(
     modifier: Modifier = Modifier,
@@ -43,7 +44,6 @@ fun VerifyEmailScreen(
     ) {
         Column(
             modifier = modifier
-                .padding(it)
                 .padding(horizontal = 16.dp)
                 .imePadding()
                 .fillMaxSize(),

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/comingSoon/ComingSoonScreen.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/comingSoon/ComingSoonScreen.kt
@@ -1,4 +1,4 @@
-package vn.tutorial.cinemate.presentation.home
+package vn.tutorial.cinemate.presentation.comingSoon
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -11,16 +11,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 
 @Composable
-fun HomeScreen() {
+fun ComingSoonScreen() {
     Scaffold {
         Column(
-            Modifier
-                .padding(it)
-                .fillMaxSize(),
+            Modifier.padding(it).fillMaxSize(),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Text("Home Screen")
+            Text("Coming Soon Screen")
         }
     }
 }

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/home/components/HeaderBar.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/home/components/HeaderBar.kt
@@ -1,0 +1,54 @@
+package vn.tutorial.cinemate.presentation.home.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import vn.tutorial.cinemate.R
+
+@Composable
+fun HeaderBar(
+    modifier: Modifier = Modifier,
+    headerItems: Map<String, () -> Unit>,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Image(
+            modifier = Modifier.weight(1f),
+            painter = painterResource(R.drawable.ic_launcher_foreground),
+            contentDescription = null
+        )
+
+        headerItems.forEach { (title, onClick) ->
+            HeaderItem(
+                modifier = Modifier.weight(1f),
+                title = title,
+                onClick = onClick
+            )
+        }
+    }
+}
+
+@Composable
+private fun HeaderItem(
+    modifier: Modifier = Modifier,
+    title: String,
+    onClick: () -> Unit = {}
+) {
+    Text(
+        modifier = modifier
+            .clickable(onClick = onClick),
+        text = title,
+        style = MaterialTheme.typography.bodyMedium,
+    )
+}

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/home/components/HeroBanner.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/home/components/HeroBanner.kt
@@ -1,0 +1,188 @@
+package vn.tutorial.cinemate.presentation.home.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import vn.tutorial.cinemate.R
+import vn.tutorial.cinemate.common.components.RatingBar
+import vn.tutorial.cinemate.common.styles.Styles
+import vn.tutorial.cinemate.presentation.home.mock.Movie
+
+val headerItems = mapOf(
+    "TV Shows" to {},
+    "Movies" to {},
+    "My List" to {}
+)
+
+@Composable
+fun HeroBanner(
+    modifier: Modifier = Modifier,
+    movie: Movie,
+    addToMyList: () -> Unit = { },
+    play: () -> Unit = { }
+) {
+    var showInfoDialog by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = modifier.padding(0.dp)
+    ) {
+        Box {
+            AsyncImage(
+                model = movie.posterUrl,
+                contentDescription = null,
+                modifier = Modifier.alpha(0.6f)
+            )
+            HeaderBar(
+                headerItems = headerItems
+            )
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceEvenly,
+
+            ) {
+            InteractionButton(
+                modifier = Modifier.weight(3f),
+                icon = R.drawable.ic_add,
+                title = stringResource(R.string.my_list),
+                onClick = addToMyList
+            )
+            Button(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .weight(4f),
+                onClick = play,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color.Gray,
+                    contentColor = Color.Black
+                ),
+                shape = Styles.ShapeStyles.mediumCorner,
+            ) {
+                Icon(
+                    Icons.Default.PlayArrow,
+                    contentDescription = null,
+                    modifier = Modifier.padding(end = 8.dp)
+                )
+                Text("Play", style = MaterialTheme.typography.bodyLarge)
+            }
+
+            InteractionButton(
+                modifier = Modifier.weight(3f),
+                icon = R.drawable.ic_info,
+                title = stringResource(R.string.movie_info),
+                onClick = {
+                    showInfoDialog = true
+                }
+            )
+
+            if (showInfoDialog) {
+                ShowInfo(
+                    movie = movie,
+                    onDismiss = { showInfoDialog = false }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun InteractionButton(
+    modifier: Modifier = Modifier,
+    icon: Int,
+    title: String,
+    onClick: () -> Unit = { }
+) {
+    Column(
+        modifier = modifier.clickable(onClick = { onClick() }),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(
+            painter = painterResource(icon),
+            contentDescription = null
+        )
+        Text(
+            text = title,
+            style = MaterialTheme.typography.bodyMedium
+        )
+    }
+}
+
+@Composable
+private fun ShowInfo(movie: Movie, onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                text = movie.title,
+                style = MaterialTheme.typography.titleMedium,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+        },
+        text = {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text(
+                    text = movie.description,
+                    style = MaterialTheme.typography.headlineSmall
+                )
+                Text(
+                    text = movie.overview,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+                RatingBar(rating = movie.rating, starSize = 28.dp)
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(
+                    "Close",
+                    color = MaterialTheme.colorScheme.primary,
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        fontWeight = FontWeight.Bold
+                    )
+                )
+            }
+        },
+        shape = Styles.ShapeStyles.largeCorner,
+    )
+}
+

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/home/components/MovieSection.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/home/components/MovieSection.kt
@@ -1,0 +1,61 @@
+package vn.tutorial.cinemate.presentation.home.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import vn.tutorial.cinemate.common.styles.Styles
+import vn.tutorial.cinemate.presentation.home.mock.Movie
+
+@Composable
+fun MovieSection(
+    sectionTitle: String,
+    movies: List<Movie>
+) {
+    Column(
+        modifier = Modifier.padding(horizontal = 16.dp)
+    ) {
+        Text(
+            text = sectionTitle,
+            style = MaterialTheme.typography.titleSmall
+        )
+        LazyRow {
+            items(movies) { movie ->
+                SectionItem(
+                    movie = movie
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionItem(
+    modifier: Modifier = Modifier,
+    movie: Movie,
+) {
+    AsyncImage(
+        modifier = modifier
+            .height(200.dp)
+            .clickable(onClick = {})
+            .padding(8.dp)
+            .clip(
+                shape = Styles.ShapeStyles.mediumCorner,
+            )
+            .aspectRatio(2f / 3f),
+        model = movie.posterUrl,
+        contentDescription = null,
+        contentScale = ContentScale.Crop
+    )
+}

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/home/screens/HomeScreen.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/home/screens/HomeScreen.kt
@@ -1,0 +1,38 @@
+package vn.tutorial.cinemate.presentation.home.screens
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import vn.tutorial.cinemate.presentation.home.components.HeroBanner
+import vn.tutorial.cinemate.presentation.home.components.MovieSection
+import vn.tutorial.cinemate.presentation.home.mock.bannerMovie
+import vn.tutorial.cinemate.presentation.home.mock.sectionData
+
+@Composable
+fun HomeScreen(
+) {
+    Scaffold(
+    ) {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(it),
+        ) {
+            item {
+                HeroBanner(movie = bannerMovie)
+            }
+
+            sectionData.forEach { (title, movies) ->
+                item {
+                    MovieSection(
+                        sectionTitle = title,
+                        movies = movies
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/more/MoreItem.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/more/MoreItem.kt
@@ -1,0 +1,59 @@
+package vn.tutorial.cinemate.presentation.more
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun MoreItem(
+    title: String,
+    onClick: () -> Unit = {},
+    icon: ImageVector
+) {
+    Column {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 16.dp, bottom = 16.dp)
+                .clickable(
+                    onClick = onClick
+                ),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Row {
+                Icon(
+                    modifier = Modifier.padding(end = 16.dp),
+                    imageVector = icon,
+                    contentDescription = null
+                )
+                Text(
+                    title,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null
+            )
+        }
+
+        HorizontalDivider(
+            thickness = 1.dp,
+        )
+    }
+}

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/more/MoreScreen.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/more/MoreScreen.kt
@@ -1,28 +1,18 @@
-package vn.tutorial.cinemate.presentation.settings.screens
+package vn.tutorial.cinemate.presentation.more
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -32,14 +22,13 @@ import vn.tutorial.cinemate.common.data.listOptions
 import vn.tutorial.cinemate.common.styles.Styles
 
 @Composable
-fun ProfileScreen(
+fun MoreScreen(
     modifier: Modifier = Modifier
 ) {
     Scaffold(
         topBar = {
             AppBar()
         },
-        bottomBar = {}
     ) {
         Column(
             modifier = modifier
@@ -68,7 +57,7 @@ fun ProfileScreen(
 
             LazyColumn {
                 items(listOptions) { option ->
-                    ProfileItem(
+                    MoreItem(
                         title = stringResource(option.titleRes),
                         icon = option.icon,
                         onClick = option.action
@@ -76,45 +65,5 @@ fun ProfileScreen(
                 }
             }
         }
-    }
-}
-
-@Composable
-fun ProfileItem(
-    title: String,
-    onClick: () -> Unit = {},
-    icon: ImageVector
-) {
-    Column {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 16.dp, bottom = 16.dp)
-                .clickable(
-                    onClick = onClick
-                ),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            Row {
-                Icon(
-                    modifier = Modifier.padding(end = 16.dp),
-                    imageVector = icon,
-                    contentDescription = null
-                )
-                Text(
-                    title,
-                    style = MaterialTheme.typography.bodyMedium
-                )
-            }
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                contentDescription = null
-            )
-        }
-
-        HorizontalDivider(
-            thickness = 1.dp,
-        )
     }
 }

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/notification/NotificationScreen.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/notification/NotificationScreen.kt
@@ -1,0 +1,25 @@
+package vn.tutorial.cinemate.presentation.notification
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun NotificationScreen() {
+
+    Scaffold {
+        Column(
+            Modifier.padding(it).fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text("Notification Screen")
+        }
+    }
+}

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/search/SearchScreen.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/search/SearchScreen.kt
@@ -1,0 +1,25 @@
+package vn.tutorial.cinemate.presentation.search
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@Composable
+fun SearchScreen() {
+    Scaffold {
+        Column(
+            Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text("Search Screen")
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_add.xml
+++ b/app/src/main/res/drawable/ic_add.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/ic_coming_soon.xml
+++ b/app/src/main/res/drawable/ic_coming_soon.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M4,6L2,6v14c0,1.1 0.9,2 2,2h14v-2L4,20L4,6zM20,2L8,2c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L22,4c0,-1.1 -0.9,-2 -2,-2zM12,14.5v-9l6,4.5 -6,4.5z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/ic_half_star.xml
+++ b/app/src/main/res/drawable/ic_half_star.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="960" android:viewportWidth="960" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M480,316L480,552L576,626L540,504L630,440L518,440L480,316ZM233,840L326,536L80,360L384,360L480,40L576,360L880,360L634,536L727,840L480,652L233,840Z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/ic_home.xml
+++ b/app/src/main/res/drawable/ic_home.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M10,20v-6h4v6h5v-8h3L12,3 2,12h3v8z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/ic_info.xml
+++ b/app/src/main/res/drawable/ic_info.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M11,7h2v2h-2V7zM11,11h2v6h-2V11zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10s10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8s8,3.59 8,8S16.41,20 12,20z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/ic_more.xml
+++ b/app/src/main/res/drawable/ic_more.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M3,18h18v-2L3,16v2zM3,13h18v-2L3,11v2zM3,6v2h18L21,6L3,6z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/ic_notification.xml
+++ b/app/src/main/res/drawable/ic_notification.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M7.58,4.08L6.15,2.65C3.75,4.48 2.17,7.3 2.03,10.5h2c0.15,-2.65 1.51,-4.97 3.55,-6.42zM19.97,10.5h2c-0.15,-3.2 -1.73,-6.02 -4.12,-7.85l-1.42,1.43c2.02,1.45 3.39,3.77 3.54,6.42zM18,11c0,-3.07 -1.64,-5.64 -4.5,-6.32L13.5,4c0,-0.83 -0.67,-1.5 -1.5,-1.5s-1.5,0.67 -1.5,1.5v0.68C7.63,5.36 6,7.92 6,11v5l-2,2v1h16v-1l-2,-2v-5zM12,22c0.14,0 0.27,-0.01 0.4,-0.04 0.65,-0.14 1.18,-0.58 1.44,-1.18 0.1,-0.24 0.15,-0.5 0.15,-0.78h-4c0.01,1.1 0.9,2 2.01,2z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/ic_search.xml
+++ b/app/src/main/res/drawable/ic_search.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/ic_star.xml
+++ b/app/src/main/res/drawable/ic_star.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M14.43,10l-2.43,-8l-2.43,8l-7.57,0l6.18,4.41l-2.35,7.59l6.17,-4.69l6.18,4.69l-2.35,-7.59l6.17,-4.41z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/ic_star_border.xml
+++ b/app/src/main/res/drawable/ic_star_border.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M22,9.24l-7.19,-0.62L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21 12,17.27 18.18,21l-1.63,-7.03L22,9.24zM12,15.4l-3.76,2.27 1,-4.28 -3.32,-2.88 4.38,-0.38L12,6.1l1.71,4.04 4.38,0.38 -3.32,2.88 1,4.28L12,15.4z"/>
+    
+</vector>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -42,4 +42,6 @@
     <string name="invalid_password">Mật khẩu phải có ít nhất 8 ký tự, chứa chữ in hoa, số và ký tự đặc biệt </string>
     <string name="not_match_password">Mật khẩu không trùng nhau</string>
 
+    <string name="movie_info">Thông tin</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,5 +39,9 @@
     <string name="invalid_email">Invalid email</string>
     <string name="invalid_password">Password must be at least 8 characters, contain uppercase letters, numbers and special characters</string>
     <string name="not_match_password">Password does not match</string>
+    
+    <string name="movie_info">Info</string>
+
+
 
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ composeBom = "2024.09.00"
 navigationCompose = "2.9.4"
 hiltVersion = "2.54"
 foundation = "1.9.1"
+coiVersion = "2.7.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -34,7 +35,7 @@ androidx-navigation-compose = { module = "androidx.navigation:navigation-compose
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hiltVersion" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hiltVersion" }
 foudation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "foundation" }
-
+coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coiVersion" }
 
 
 [plugins]


### PR DESCRIPTION
This commit introduces the HomeScreen with a HeroBanner and MovieSections, and sets up the main navigation graph with a BottomBar.

- Added `HomeScreen` displaying a hero banner and sections for movies.
- Implemented `HeroBanner` with movie details, interactions (add to list, play, show info dialog).
- Added `MovieSection` to display lists of movies.
- Created `HeaderBar` for navigation within the home screen.
- Implemented `BottomBar` for main app navigation (Home, Search, Coming Soon, Notification, More).
- Added `SearchScreen`, `ComingSoonScreen`, `NotificationScreen`, and `MoreScreen` as placeholders.
- `MoreScreen` (previously ProfileScreen) displays user options.
- Added `RatingBar` component.
- Added new icons for navigation and actions.
- Added Coil library for image loading.
- Updated `AppNavGraph` to include new screens and navigation logic.
- Updated `Route.kt` with new routes.
- Added "movie_info" string resource.
- Added internet and network state permissions to `AndroidManifest.xml`.
- Removed `padding(it)` from authentication screens as `Scaffold` is not used directly.
- Removed unused `ProfileScreen` and old `HomeScreen`.
- Updated `SignInText` to remove explicit white color.