### PR TITLE
feat: Implement API error handling and refine auth flow

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,5 +77,6 @@ dependencies {
     implementation(libs.retrofit)
 
     implementation(libs.security.crypto)
+    implementation(libs.gson)
 
 }

--- a/app/src/main/java/vn/tutorial/cinemate/core/constant/ApiEndpoints.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/core/constant/ApiEndpoints.kt
@@ -1,7 +1,7 @@
 package vn.tutorial.cinemate.core.constant
 
 object ApiEndpoints {
-    const val BASE_URL = "https://cinemate-api/"
+    const val BASE_URL = "https://27240b75-c170-4625-b3c2-9f3bdef0f9e6.mock.pstmn.io/"
 
     // todo Authentication
     const val SIGN_UP = "sign-up"

--- a/app/src/main/java/vn/tutorial/cinemate/data/remote/responses/authentication/BaseResponse.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/data/remote/responses/authentication/BaseResponse.kt
@@ -5,9 +5,9 @@ import com.google.gson.annotations.SerializedName
 data class BaseResponse<T>(
     @SerializedName("status") val status: String,
     @SerializedName("data") val data: T? = null,      // nullable
-    @SerializedName("message") val message: String?,  // nullable
-    @SerializedName("path") val path: String?,
-    @SerializedName("method") val method: String?,
+    @SerializedName("message") val message: String? =null,  // nullable
+    @SerializedName("path") val path: String? = null,
+    @SerializedName("method") val method: String? = null,
 
 
     // khi có lỗi từ server

--- a/app/src/main/java/vn/tutorial/cinemate/data/remote/responses/authentication/SignUpResponse.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/data/remote/responses/authentication/SignUpResponse.kt
@@ -3,13 +3,7 @@ package vn.tutorial.cinemate.data.remote.responses.authentication
 import com.google.gson.annotations.SerializedName
 import vn.tutorial.cinemate.domain.model.UserModel
 
-//data class SignUpResponse(
-//    @SerializedName("status") val status: String,
-//    @SerializedName("data") val data: DataWrapperSignUp,
-//    @SerializedName("message") val message: String,
-//    @SerializedName("path") val path: String,
-//    @SerializedName("method") val method: String
-//)
+
 
 data class DataWrapperSignUp(
     @SerializedName("user") val user: UserDto

--- a/app/src/main/java/vn/tutorial/cinemate/data/remote/services/AuthService.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/data/remote/services/AuthService.kt
@@ -1,5 +1,6 @@
 package vn.tutorial.cinemate.data.remote.services
 
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST
 import vn.tutorial.cinemate.core.constant.ApiEndpoints
@@ -13,28 +14,29 @@ import vn.tutorial.cinemate.data.remote.responses.authentication.DataWrapperSign
 import vn.tutorial.cinemate.data.remote.responses.authentication.DataWrapperSignUp
 
 interface AuthService {
+
     @POST(ApiEndpoints.SIGN_UP)
     suspend fun signUp(
         @Body signUpRequest: SignUpRequest
-    ): BaseResponse<DataWrapperSignUp>
+    ): Response<BaseResponse<DataWrapperSignUp>>
 
     @POST(ApiEndpoints.VERIFY_OTP)
     suspend fun verifyOTP(
         @Body verifyOTPRequest: VerifyOTPRequest
-    ): BaseResponse<Boolean>
+    ): Response<BaseResponse<Boolean>>
 
     @POST(ApiEndpoints.FORGOT_PASSWORD)
     suspend fun forgotPassword(
         @Body forgotPasswordRequest: VerifyEmailRequest
-    ): BaseResponse<String>
+    ): Response<BaseResponse<String>>
 
     @POST(ApiEndpoints.RESET_PASSWORD)
     suspend fun resetPassword(
         @Body resetPasswordRequest: ResetPasswordRequest
-    ): BaseResponse<String>
+    ): Response<BaseResponse<String>>
 
     @POST(ApiEndpoints.LOGIN)
     suspend fun signIn(
         @Body signInRequest: SignInRequest
-    ): BaseResponse<DataWrapperSignIn>
+    ): Response<BaseResponse<DataWrapperSignIn>>
 }

--- a/app/src/main/java/vn/tutorial/cinemate/data/repositoryImpl/AuthRepositoryImpl.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/data/repositoryImpl/AuthRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package vn.tutorial.cinemate.data.repositoryImpl
 
-import coil.network.HttpException
+import com.google.gson.Gson
+import retrofit2.Response
 import vn.tutorial.cinemate.core.base_class.Resource
 import vn.tutorial.cinemate.core.util.LogUtil
 import vn.tutorial.cinemate.data.local.TokenStorage
@@ -30,20 +31,28 @@ class AuthRepositoryImpl @Inject constructor(
     }
 
     private suspend fun <T> safeApiCall(
-        apiCall: suspend () -> BaseResponse<T>
+        apiCall: suspend () -> Response<BaseResponse<T>>
     ): Resource<T?> {
         return try {
             val response = apiCall()
-            if (response.status == "success") {
-                Resource.Success(response.data)
+            if (response.isSuccessful) {
+                val body = response.body()
+                if (body != null && body.status == "success") {
+                    Resource.Success(body.data)
+                } else {
+                    Resource.Error(body?.detail ?: body?.message ?: "An unexpected error occurred")
+                }
             } else {
-                Resource.Error(response.detail ?: "An unexpected error occurred")
+                val errorBody = response.errorBody().toString()
+                LogUtil(errorBody)
+                val errorResponse = Gson().fromJson(errorBody, BaseResponse::class.java)
+                LogUtil(errorResponse.toString())
+                Resource.Error(
+                    errorResponse?.detail ?: errorResponse?.message
+                    ?: "An unexpected error occurred"
+                )
             }
-        } catch (e: HttpException) {
-            LogUtil("Lot vao safeApiCall 1")
-            Resource.Error(e.message ?: "An unexpected error occurred")
         } catch (e: Exception) {
-            LogUtil("Lot vao safeApiCall 2")
             Resource.Error(e.message ?: "An unexpected error occurred")
         }
     }

--- a/app/src/main/java/vn/tutorial/cinemate/domain/usecase/authentication/SignUpUseCase.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/domain/usecase/authentication/SignUpUseCase.kt
@@ -19,7 +19,6 @@ class SignUpUseCase @Inject constructor(
     )
 
     override suspend fun execute(param: Params): Resource<UserModel?> {
-        Log.d("SignUp", "Call sign up use case")
         return authRepository.signUp(
             email = param.email,
             firstName = param.firstName,

--- a/app/src/main/java/vn/tutorial/cinemate/navigation/AppNavGraph.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/navigation/AppNavGraph.kt
@@ -73,11 +73,11 @@ fun NavGraphBuilder.authenticationNavGraph(navController: NavHostController) {
     // todo gom các màn forgot password thành 1 graph con
     navigation(
         startDestination = Route.VerifyEmail.route,
-        route = "forgot_password_graph"
+        route = Route.ForgotPasswordGraph.route
     ) {
         composable(route = Route.VerifyEmail.route) {
             val parentEntry = remember(navController) {
-                navController.getBackStackEntry("forgot_password_graph")
+                navController.getBackStackEntry(Route.ForgotPasswordGraph.route)
             }
             val viewModel: ForgotPasswordViewModel = hiltViewModel(parentEntry)
 
@@ -90,7 +90,7 @@ fun NavGraphBuilder.authenticationNavGraph(navController: NavHostController) {
 
         composable(route = Route.ChangePassword.route) {
             val parentEntry = remember(navController) {
-                navController.getBackStackEntry("forgot_password_graph")
+                navController.getBackStackEntry(Route.ForgotPasswordGraph.route)
             }
             val viewModel: ForgotPasswordViewModel = hiltViewModel(parentEntry)
 
@@ -104,11 +104,11 @@ fun NavGraphBuilder.authenticationNavGraph(navController: NavHostController) {
     // todo sign up graph
     navigation(
         startDestination = Route.SignUp.route,
-        route = "sign_up_graph"
+        route = Route.SignInGraph.route
     ) {
         composable(route = Route.SignUp.route) {
             val parentEntry = remember(navController) {
-                navController.getBackStackEntry("sign_up_graph")
+                navController.getBackStackEntry(Route.SignInGraph.route)
             }
             val viewModel: SignUpViewModel = hiltViewModel(parentEntry)
             SignUpScreen(navController = navController, viewModel = viewModel)
@@ -116,7 +116,7 @@ fun NavGraphBuilder.authenticationNavGraph(navController: NavHostController) {
 
         composable(route = Route.CreatePassword.route) {
             val parentEntry = remember(navController) {
-                navController.getBackStackEntry("sign_up_graph")
+                navController.getBackStackEntry(Route.SignInGraph.route)
             }
             val viewModel: SignUpViewModel = hiltViewModel(parentEntry)
             CreatePasswordScreen(navController = navController, viewModel = viewModel)

--- a/app/src/main/java/vn/tutorial/cinemate/navigation/Route.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/navigation/Route.kt
@@ -4,6 +4,8 @@ sealed class Route(val route: String) {
     //todo route splash
     object Started: Route("started")
     object Splash: Route("splash")
+    object SignInGraph: Route("sign_in_graph")
+    object ForgotPasswordGraph: Route("forgot_password_graph")
 
     // todo route auth
     object SignIn: Route("sign_in")

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/CreatePasswordScreen.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/CreatePasswordScreen.kt
@@ -43,11 +43,11 @@ fun CreatePasswordScreen(
         navController.getBackStackEntry("sign_up_graph")
     )
 ) {
-    val state = viewModel.state.collectAsState()
+    val state = viewModel.state.collectAsState().value
 
-    LaunchedEffect(state.value.user) {
-        if (state.value.user != null) {
-            navController.navigate(Route.CheckMail.createRoute(email = state.value.email)) {
+    LaunchedEffect(state.user) {
+        if (state.user != null) {
+            navController.navigate(Route.CheckMail.createRoute(email = state.email)) {
                 popUpTo(Route.SignUp.route) {
                     inclusive = true
                 }
@@ -84,7 +84,7 @@ fun CreatePasswordScreen(
 
             CommonTextField(
                 modifier = Modifier.padding(top = 16.dp),
-                value = state.value.firstName,
+                value = state.firstName,
                 onValueChange = {
                     viewModel.updateFirstName(it)
                     isFirstNameValid = it.isNotEmpty()
@@ -96,7 +96,7 @@ fun CreatePasswordScreen(
 
             CommonTextField(
                 modifier = Modifier.padding(top = 16.dp),
-                value = state.value.lastName,
+                value = state.lastName,
                 onValueChange = {
                     viewModel.updateLastName(it)
                     isLastNameValid = it.isNotEmpty()
@@ -109,7 +109,7 @@ fun CreatePasswordScreen(
 
             PasswordTextField(
                 modifier = Modifier.padding(top = 16.dp),
-                value = state.value.password,
+                value = state.password,
                 onValueChange = {
                     viewModel.updatePassword(it)
                     isValidPassword = Validator.isValidPassword(it)
@@ -120,10 +120,10 @@ fun CreatePasswordScreen(
 
             PasswordTextField(
                 modifier = Modifier.padding(top = 16.dp),
-                value = state.value.passwordConfirm,
+                value = state.passwordConfirm,
                 onValueChange = {
                     viewModel.updatePasswordConfirm(it)
-                    isMatch = it == state.value.password
+                    isMatch = it == state.password
                 },
                 isValidPassword = isMatch,
                 errorMessage = if (isMatch == false) stringResource(R.string.not_match_password) else null
@@ -145,16 +145,16 @@ fun CreatePasswordScreen(
                             isMatch = false
                         }
 
-                        isFirstNameValid = state.value.firstName.isNotEmpty()
-                        isLastNameValid = state.value.lastName.isNotEmpty()
+                        isFirstNameValid = state.firstName.isNotEmpty()
+                        isLastNameValid = state.lastName.isNotEmpty()
 
                     }
                 })
         }
 
         LoadingAndError(
-            isLoading = state.value.isLoading,
-            error = state.value.error,
+            isLoading = state.isLoading,
+            error = state.error,
             onErrorDismiss = { viewModel.clearError() })
 
     }

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/SignUpScreen.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/SignUpScreen.kt
@@ -44,7 +44,7 @@ fun SignUpScreen(
         navController.getBackStackEntry("sign_up_graph")
     )
 ) {
-    val state = viewModel.state.collectAsState()
+    val state = viewModel.state.collectAsState().value
     var isChecked by remember { mutableStateOf(false) }
     var isValidEmail: Boolean? by remember { mutableStateOf(null) }
 
@@ -74,7 +74,7 @@ fun SignUpScreen(
             EmailTextField(
                 modifier = Modifier
                     .padding(top = 16.dp),
-                value = state.value.email,
+                value = state.email,
                 onValueChange = {
                     viewModel.updateEmail(it)
                     isValidEmail = Validator.isValidEmail(it)

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/VerifyEmailScreen.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/VerifyEmailScreen.kt
@@ -42,7 +42,7 @@ fun VerifyEmailScreen(
     )
 ) {
 
-    val state = viewModel.state.collectAsState()
+    val state = viewModel.state.collectAsState().value
 
     Scaffold(
         topBar = {
@@ -75,7 +75,7 @@ fun VerifyEmailScreen(
                 style = MaterialTheme.typography.bodyMedium,
             )
             EmailTextField(
-                value = state.value.email,
+                value = state.email,
                 onValueChange = {
                     viewModel.updateEmail(it)
                     isValidEmail = Validator.isValidEmail(it)
@@ -100,8 +100,8 @@ fun VerifyEmailScreen(
         }
 
         LoadingAndError(
-            isLoading = state.value.isLoading,
-            error = state.value.error,
+            isLoading = state.isLoading,
+            error = state.error,
             onErrorDismiss = {
                 viewModel.clearError()
             }

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/VerifyOTPScreen.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/authentication/screens/VerifyOTPScreen.kt
@@ -41,9 +41,9 @@ fun VerifyOTPScreen(
 ) {
     val navController = LocalNavController.current
 
-    val state = viewModel.state.collectAsState()
+    val state = viewModel.state.collectAsState().value
 
-    val focusRequesters = remember { List(state.value.otp.size) { FocusRequester() } }
+    val focusRequesters = remember { List(state.otp.size) { FocusRequester() } }
 
     Scaffold(
         topBar = {
@@ -73,7 +73,7 @@ fun VerifyOTPScreen(
             // 4 ô verity OTP code
 
             Row(horizontalArrangement = Arrangement.spacedBy(24.dp)) {
-                state.value.otp.forEachIndexed { index, digit ->
+                state.otp.forEachIndexed { index, digit ->
                     OutlinedTextField(
                         value = if (digit == -1) "" else digit.toString(),
                         onValueChange = { value ->
@@ -105,7 +105,7 @@ fun VerifyOTPScreen(
                 title = stringResource(R.string.confirm),
                 onClick = {
 
-                    if (!state.value.otp.contains(-1)) {
+                    if (!state.otp.contains(-1)) {
                         Log.d("SignUp", "onClick: ${viewModel.getOtpCode()}")
                         viewModel.verifyOTP(
                             otp = viewModel.getOtpCode(),
@@ -123,8 +123,8 @@ fun VerifyOTPScreen(
         }
 
         LoadingAndError(
-            isLoading = state.value.isLoading,
-            error = state.value.error,
+            isLoading = state.isLoading,
+            error = state.error,
             onErrorDismiss = {
                 viewModel.clearError()
             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ coiVersion = "2.7.0"
 retrofit = "2.9.0"
 converterGson = "2.9.0"
 encrypted = "1.1.0"
+googleGson = "2.10.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -50,6 +51,7 @@ androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navig
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "converterGson" }
 security-crypto = { module = "androidx.security:security-crypto", version.ref = "encrypted" }
+gson = { module = "com.google.code.gson:gson", version.ref = "googleGson" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This commit introduces robust error handling for API calls by parsing error responses and refines the authentication navigation flow.

- **API Error Handling**:
    - Updated `AuthRepositoryImpl` to properly handle non-2xx HTTP responses. It now uses `Gson` to parse the error body from the server, providing more descriptive error messages to the user instead of generic exceptions.
    - Wrapped `BaseResponse` with Retrofit's `Response` in `AuthService` to access the full HTTP response, including status codes and error bodies.
    - Added the `com.google.code.gson` dependency.

- **Authentication Flow Refinements**:
    - Defined explicit navigation graph routes (`SignInGraph`, `ForgotPasswordGraph`) in `Route.kt` and updated `AppNavGraph.kt` to use them, improving navigation structure.
    - Simplified state access in `SignUpScreen`, `CreatePasswordScreen`, `VerifyEmailScreen`, and `VerifyOTPScreen` by directly using `.value` on the collected state.

- **Configuration**:
    - Updated the `BASE_URL` in `ApiEndpoints.kt` to a mock Postman URL for development and testing.