### PR TITLE
feat: Replace Notification tab with Subscription and refactor UI

### DIFF
--- a/app/src/main/java/vn/tutorial/cinemate/common/components/BottomBar.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/common/components/BottomBar.kt
@@ -2,6 +2,8 @@ package vn.tutorial.cinemate.common.components
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.height
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ShoppingCart
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
@@ -14,13 +16,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import vn.tutorial.cinemate.common.icons.AppIcons
+import vn.tutorial.cinemate.R
+import vn.tutorial.cinemate.navigation.Route
 
 data class BottomNavItem(
     val label: String,
@@ -31,10 +35,10 @@ data class BottomNavItem(
 @Composable
 fun BottomBar(navController: NavHostController) {
     val items = listOf(
-        BottomNavItem("Home", AppIcons.home(), "home"),
-        BottomNavItem("Search", AppIcons.search(), "search"),
-        BottomNavItem("Notification", AppIcons.notification(), "notification"),
-        BottomNavItem("More", AppIcons.more(), "more")
+        BottomNavItem(stringResource(R.string.home), AppIcons.home(), "home"),
+        BottomNavItem(stringResource(R.string.search), AppIcons.search(), "search"),
+        BottomNavItem(stringResource(R.string._package), AppIcons.services(), Route.Subscription.route),
+        BottomNavItem(stringResource(R.string.more), AppIcons.more(), "more")
     )
 
     NavigationBar(

--- a/app/src/main/java/vn/tutorial/cinemate/common/data/ProfileOption.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/common/data/ProfileOption.kt
@@ -48,16 +48,16 @@ val listOptions = listOf(
 //        Icons.Default.Face,
 //        route =  Route.ChildrenMode.route
 //    ),
-    ProfileOption(
-        R.string.package_management,
-        Icons.Default.ShoppingCart,
-        route =  Route.Subscription.route
-    ),
-    ProfileOption(
-        R.string.notification_management,
-        Icons.Default.Notifications,
-        route = Route.SettingNotification.route
-    ),
+//    ProfileOption(
+//        R.string.package_management,
+//        Icons.Default.ShoppingCart,
+//        route =  Route.Subscription.route
+//    ),
+//    ProfileOption(
+//        R.string.notification_management,
+//        Icons.Default.Notifications,
+//        route = Route.SettingNotification.route
+//    ),
     ProfileOption(
         R.string.theme_language,
         Icons.Default.Settings,

--- a/app/src/main/java/vn/tutorial/cinemate/common/icons/AppIcons.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/common/icons/AppIcons.kt
@@ -97,7 +97,7 @@ object AppIcons {
     fun history(): Painter = painterResource(R.drawable.ic_history)
 
     @Composable
-    fun services(): Painter = painterResource(R.drawable.ic_service)
+    fun services(): Painter = painterResource(R.drawable.ic_card)
 
     @Composable
     fun signOut(): Painter = painterResource(R.drawable.ic_signout)

--- a/app/src/main/java/vn/tutorial/cinemate/navigation/App.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/navigation/App.kt
@@ -31,7 +31,7 @@ fun App(
     val routeHasBottomBar = listOf(
         Route.Home.route,
         Route.ComingSoon.route,
-        Route.Notification.route,
+        Route.Subscription.route,
         Route.Search.route,
         Route.More.route,
     )

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/more/screens/SubscriptionScreen.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/more/screens/SubscriptionScreen.kt
@@ -9,13 +9,17 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -29,6 +33,7 @@ import vn.tutorial.cinemate.presentation.more.components.TopAppBarWithBack
 import vn.tutorial.cinemate.presentation.more.viewModels.SubscriptionPlanViewModel
 import androidx.core.net.toUri
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SubscriptionScreen(
     title: String = "Subscription",
@@ -42,8 +47,19 @@ fun SubscriptionScreen(
 
     Scaffold(
         topBar = {
-            TopAppBarWithBack(
-                title = title
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.package_management),
+                        style = MaterialTheme.typography.titleSmall,
+                    )
+                },
+
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Color.Transparent,
+                    titleContentColor = MaterialTheme.colorScheme.onBackground,
+                    actionIconContentColor = MaterialTheme.colorScheme.onBackground
+                )
             )
         },
     ) {
@@ -53,18 +69,18 @@ fun SubscriptionScreen(
                 .padding(it)
                 .padding(horizontal = 16.dp)
         ) {
-            Text(
-                text = stringResource(R.string.choose_your_plan),
-                color = MaterialTheme.colorScheme.onBackground,
-                style = MaterialTheme.typography.titleSmall,
-                textAlign = TextAlign.Center,
-                modifier = Modifier
-                    .padding(bottom = 16.dp)
-                    .fillMaxWidth()
-            )
+//            Text(
+//                text = stringResource(R.string.choose_your_plan),
+//                color = MaterialTheme.colorScheme.onBackground,
+//                style = MaterialTheme.typography.titleSmall,
+//                textAlign = TextAlign.Center,
+//                modifier = Modifier
+//                    .padding(bottom = 16.dp)
+//                    .fillMaxWidth()
+//            )
 
             LazyColumn(
-                modifier = Modifier.weight(1f),
+                modifier = Modifier.weight(1f).padding(bottom = 80.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
                 items(state.plans) { plan ->
@@ -74,20 +90,20 @@ fun SubscriptionScreen(
                         onSelect = viewModel::selectPlan
                     )
                 }
-            }
-
-            CommonButton(
-                title = stringResource(R.string.continue_text),
-                modifier = Modifier
-                    .padding(vertical = 24.dp)
-                    .fillMaxWidth(),
-                onClick = {
-                    viewModel.paySubscription{url ->
-                        val intent = Intent(Intent.ACTION_VIEW, url.toUri())
-                        context.startActivity(intent)
-                    }
+                item {
+                    CommonButton(
+                        title = stringResource(R.string.continue_text),
+                        modifier = Modifier
+                            .fillMaxWidth().padding(vertical = 16.dp),
+                        onClick = {
+                            viewModel.paySubscription{url ->
+                                val intent = Intent(Intent.ACTION_VIEW, url.toUri())
+                                context.startActivity(intent)
+                            }
+                        }
+                    )
                 }
-            )
+            }
         }
 
         LoadingAndError(

--- a/app/src/main/java/vn/tutorial/cinemate/presentation/search/screens/SearchScreen.kt
+++ b/app/src/main/java/vn/tutorial/cinemate/presentation/search/screens/SearchScreen.kt
@@ -46,6 +46,7 @@ fun SearchScreen(
             TopAppBar(
                 title = {
                     SearchBar(
+                        modifier = Modifier.fillMaxSize().padding(top = 16.dp),
                         value = state.query,
                         onChange = { searchViewModel.updateQuery(it) },
                         onSearch = {

--- a/app/src/main/res/drawable/ic_card.xml
+++ b/app/src/main/res/drawable/ic_card.xml
@@ -1,0 +1,29 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:viewportHeight="60" android:viewportWidth="60" android:width="24dp">
+      
+    <path android:fillColor="#000000" android:pathData="M55.783,8H4.217C1.892,8 0,9.892 0,12.217v35.566C0,50.108 1.892,52 4.217,52h51.566C58.108,52 60,50.108 60,47.783V12.217C60,9.892 58.108,8 55.783,8zM58,47.783C58,49.005 57.006,50 55.783,50H4.217C2.994,50 2,49.005 2,47.783V12.217C2,10.995 2.994,10 4.217,10h51.566C57.006,10 58,10.995 58,12.217V47.783z"/>
+      
+    <path android:fillColor="#000000" android:pathData="M6,18h9c0.553,0 1,-0.448 1,-1s-0.447,-1 -1,-1H6c-0.553,0 -1,0.448 -1,1S5.447,18 6,18z"/>
+      
+    <path android:fillColor="#000000" android:pathData="M28,16h-9c-0.553,0 -1,0.448 -1,1s0.447,1 1,1h9c0.553,0 1,-0.448 1,-1S28.553,16 28,16z"/>
+      
+    <path android:fillColor="#000000" android:pathData="M6,23h1c0.553,0 1,-0.448 1,-1s-0.447,-1 -1,-1H6c-0.553,0 -1,0.448 -1,1S5.447,23 6,23z"/>
+      
+    <path android:fillColor="#000000" android:pathData="M11,21c-0.553,0 -1,0.448 -1,1s0.447,1 1,1h2c0.553,0 1,-0.448 1,-1s-0.447,-1 -1,-1H11z"/>
+      
+    <path android:fillColor="#000000" android:pathData="M19,22c0,-0.552 -0.447,-1 -1,-1h-1c-0.553,0 -1,0.448 -1,1s0.447,1 1,1h1C18.553,23 19,22.552 19,22z"/>
+      
+    <path android:fillColor="#000000" android:pathData="M24,23c0.553,0 1,-0.448 1,-1s-0.447,-1 -1,-1h-2c-0.553,0 -1,0.448 -1,1s0.447,1 1,1H24z"/>
+      
+    <path android:fillColor="#000000" android:pathData="M27.29,21.29C27.109,21.48 27,21.74 27,22c0,0.26 0.109,0.52 0.29,0.71C27.479,22.89 27.74,23 28,23c0.27,0 0.52,-0.11 0.71,-0.29C28.89,22.52 29,22.26 29,22c0,-0.26 -0.11,-0.52 -0.29,-0.71C28.33,20.92 27.66,20.92 27.29,21.29z"/>
+      
+    <path android:fillColor="#000000" android:pathData="M37,27h18V15H37V27zM39,17h14v8H39V17z"/>
+      
+    <path android:fillColor="#000000" android:pathData="M5,45h11v-8H5V45zM7,39h7v4H7V39z"/>
+      
+    <path android:fillColor="#000000" android:pathData="M18,45h11v-8H18V45zM20,39h7v4h-7V39z"/>
+      
+    <path android:fillColor="#000000" android:pathData="M31,45h11v-8H31V45zM33,39h7v4h-7V39z"/>
+      
+    <path android:fillColor="#000000" android:pathData="M44,45h11v-8H44V45zM46,39h7v4h-7V39z"/>
+    
+</vector>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -36,7 +36,7 @@
     <string name="watching_history">Lịch sử xem</string>
     <string name="my_list">Yêu thích</string>
     <string name="children_mode">Chế độ trẻ em</string>
-    <string name="package_management">Quản lý gói dịch vụ</string>
+    <string name="package_management">Dịch vụ</string>
     <string name="notification_management">Quản lý thông báo</string>
     <string name="help_reply">Trợ giúp và phàn hồi</string>
     <string name="sign_out">Đăng xuất</string>
@@ -76,6 +76,7 @@
     <string name="cancel">Hủy</string>
     <string name="result">Kết quả</string>
 
+    <string name="trending">Thịnh hành</string>
     <string name="receive_notifications">Nhận thông báo</string>
     <string name="deny_notifications">Từ chối thông báo</string>
     <string name="deny_notifications_desc">Bạn đã từ chối quyền nhận thông báo. Vui lòng bật lại quyền này trong cài đặt hệ thống để nhận thông báo mới</string>
@@ -105,4 +106,8 @@
     <string name="multiple_devices">Nhiều thiết bị</string>
     <string name="family_sharing">Chia sẻ gia đình</string>
     <string name="days">ngày</string>
+    <string name="home">Trang chủ</string>
+    <string name="search">Tìm kiếm</string>
+    <string name="more">Khác</string>
+    <string name="_package">Dịch vụ</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,7 +37,7 @@
     <string name="watching_history">Watching history</string>
     <string name="my_list">My list</string>
     <string name="children_mode">Children Mode</string>
-    <string name="package_management">"Service package management "</string>
+    <string name="package_management">"Package"</string>
     <string name="notification_management">Notification management</string>
     <string name="help_reply">Help and reply</string>
     <string name="sign_out">Sign out</string>
@@ -76,7 +76,7 @@
     <string name="sign_out_confirm">Are you sure you want to sign out?</string>
     <string name="cancel">Cancel</string>
     <string name="result">Results</string>
-    <string name="trending" translatable="false">Trending</string>
+    <string name="trending">Trending</string>
 
     <string name="receive_notifications">Receive Notifications</string>
     <string name="deny_notifications">Notifications denied</string>
@@ -115,5 +115,9 @@
     <string name="multiple_devices">Multiple Devices</string>
     <string name="family_sharing">Family Sharing</string>\
     <string name="days">days</string>
+    <string name="home">Home</string>
+    <string name="search">Search</string>
+    <string name="more">More</string>
+    <string name="_package">Package</string>
 
 </resources>


### PR DESCRIPTION
This commit replaces the Notification tab in the bottom navigation with the Subscription/Package screen and updates related UI components.

- Replaced the "Notification" item in `BottomBar` with a "Package" item linking to `Route.Subscription.route`.
- Updated `App.kt` to display the bottom bar for the Subscription route instead of Notification.
- Refactored `SubscriptionScreen` to use `CenterAlignedTopAppBar`, removed the "Choose your plan" text, and moved the "Continue" button into the scrollable list.
- Added `ic_card.xml` vector drawable and updated `AppIcons.kt` to use it for the services icon.
- Adjusted `SearchScreen` layout to fill max size with top padding.
- Temporarily commented out package and notification management options in `ProfileOption.kt`.
- Updated `strings.xml` in English and Vietnamese with new resources for navigation labels (Home, Search, More, Package) and updated existing translations.